### PR TITLE
Prefix input to make hash lookup harder

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,8 @@
             var password = document.querySelectorAll('[data-id="password"]')
 
             function login(secret) {
-                var hash = sha1(secret)
+                var prefix = 'protected-github-pages-';
+                var hash = sha1(prefix + secret)
                 var url = hash + "/index.html"
                 var alert = document.querySelectorAll('[data-id="alert"]')
 


### PR DESCRIPTION
Right now, `sha1(input)` is exposed in the URL. 
For short and well-known passwords, hashes can be looked up easily. 
E.g. https://www.google.com/search?q=5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8
This URL exposes the password, and it's saved in browsing history. 
By prefixing the password with a string, such lookups are harder.

**This breaks existing passwords.** 

Far better would be a real salt, but that would require the salt state to be embedded in the page (https://en.wikipedia.org/wiki/Salt_(cryptography)). 